### PR TITLE
Add platform element to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,13 +23,15 @@
 	</js-module>
 
 	<!-- android -->
-	<source-file src="src/android/SocialShare.java" target-dir="src/com/gestionaleauto/" />
-				
-	<config-file target="res/xml/config.xml" parent="/*">
-		<feature name="SocialShare" >
-			<param name="android-package" value="com.gestionaleauto.SocialShare"/>
-		</feature>
-	</config-file>
+	<platform name="android">
+		<source-file src="src/android/SocialShare.java" target-dir="src/com/gestionaleauto/" />
+					
+		<config-file target="res/xml/config.xml" parent="/*">
+			<feature name="SocialShare" >
+				<param name="android-package" value="com.gestionaleauto.SocialShare"/>
+			</feature>
+		</config-file>
+	</platform>
 	
 </plugin>
 


### PR DESCRIPTION
Add `<platform>` tag to identify Android platform native code. Plugins without `<platform>` tags are assumed to be JavaScript-only, and therefore installable on any and all platforms, which is not the case here.
