### PR TITLE
Fix: window.plugins no longer works on cordova > 3.3, changed to

### DIFF
--- a/www/SocialShare.js
+++ b/www/SocialShare.js
@@ -25,11 +25,11 @@ SocialShare.prototype.share = function(successCallback, errorCallback, options) 
 
 //-------------------------------------------------------------------
 
-if(!window.plugins) {
-    window.plugins = {};
+if(!cordova.plugins) {
+    cordova.plugins = {};
 }
-if (!window.plugins.SocialShare) {
-    window.plugins.SocialShare = new SocialShare();
+if (!cordova.plugins.SocialShare) {
+    cordova.plugins.SocialShare = new SocialShare();
 }
 
 if (module.exports) {


### PR DESCRIPTION
cordova.plugins. Hey, due to recent changes this change will be needed to use the plugin with cordova > 3.3(I guess)
